### PR TITLE
Hotfix/await asyncio sleep

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ And see example.
                     last_seen_message_id=-1
                 )
             except exceptions.ServerRestart:
-                asyncio.sleep(60)
+                await asyncio.sleep(60)
 
 
     if __name__ == '__main__':

--- a/cryptology/market_data_client.py
+++ b/cryptology/market_data_client.py
@@ -11,7 +11,7 @@ from . import exceptions, common
 from datetime import datetime
 from decimal import Decimal
 
-__all__ = ('run')
+__all__ = ('run',)
 
 
 logger = logging.getLogger(__name__)

--- a/examples/client.py
+++ b/examples/client.py
@@ -46,7 +46,7 @@ async def main():
                 last_seen_message_id=-1
             )
         except exceptions.ServerRestart:
-            asyncio.sleep(60)
+            await asyncio.sleep(60)
 
 
 if __name__ == '__main__':

--- a/examples/market_maker.py
+++ b/examples/market_maker.py
@@ -112,7 +112,7 @@ async def main():
             get_balances=True
         )
     except exceptions.ServerRestart:
-        asyncio.sleep(60)
+        await asyncio.sleep(60)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. asyncio sleep coroutine was not awaited so it had no effect (you had hundreds of reconnects per second on ServerRestart exception).
2. `__all__` in market_data_client was broken (string instead of tuple/list) so `import *` was not working (mass import is the only reason you might need `__all__`)